### PR TITLE
Fix Entry node missing problem happening in PjOrion v2 sample

### DIFF
--- a/simplifier.py
+++ b/simplifier.py
@@ -50,6 +50,9 @@ class Simplifier:
                         if forwardedBB_in_edge_exists and forwarderBB_in_edge_exists:
                             continue
 
+                        if forwarderBB in nx.get_node_attributes(self.bb_graph,'isEntry').keys():
+                            nx.set_node_attributes(self.bb_graph, 'isEntry', {forwardedBB: True})
+
                         # Remove the edge between forwarder and forwarded
                         self.bb_graph.remove_edge(forwarderBB, forwardedBB)
 


### PR DESCRIPTION
Error info:

```python
INFO:simplifier:43 basic blocks eliminated
Traceback (most recent call last):
  File "./main.py", line 72, in <module>
    process(args.ifile, args.ofile)
  File "./main.py", line 58, in process
    deob = parse_code_object(rootCodeObject)
  File "./main.py", line 20, in parse_code_object
    co_codestring = deobfuscate(codeObject.co_code)
  File "/tmp/sim/deobfuscator.py", line 75, in deobfuscate
    render_graph(simplifier.bb_graph, 'after_forwarder.svg')
  File "/tmp/sim/utils/rendergraph.py", line 34, in render_graph
    entryblock = nx.get_node_attributes(bb_graph, 'isEntry').keys()[0]
IndexError: list index out of range
```

It happened when the node labeled `isEntry` is merged with other node, without passing its `isEntry` attribute. So there's no available `isEntry` node left after first forward elimination.

This is sample pyc file for you to test. : ) [py.zip](https://github.com/extremecoders-re/bytecode_simplifier/files/3545340/py.zip)
